### PR TITLE
CI: add workflow to test GraphQL queries against OCaml node

### DIFF
--- a/.github/scripts/test-graphql-remote/wait-for-graphql.sh
+++ b/.github/scripts/test-graphql-remote/wait-for-graphql.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Wait for GraphQL endpoint to become available
+# Usage: ./wait-for-graphql.sh [GRAPHQL_ENDPOINT] [TIMEOUT_SECONDS] [CHECK_INTERVAL]
+
+set -e
+
+GRAPHQL_ENDPOINT="${1:-http://localhost:3085/graphql}"
+TIMEOUT_SECONDS="${2:-60}"
+CHECK_INTERVAL="${3:-2}"
+
+echo "Waiting for GraphQL endpoint to become available..."
+echo "Endpoint: $GRAPHQL_ENDPOINT"
+echo "Timeout: ${TIMEOUT_SECONDS}s, Check interval: ${CHECK_INTERVAL}s"
+
+MAX_ATTEMPTS=$(( TIMEOUT_SECONDS / CHECK_INTERVAL ))
+
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if curl -s --max-time 5 -X POST "$GRAPHQL_ENDPOINT" \
+       -H "Content-Type: application/json" \
+       -d '{"query":"{ networkID }"}' > /dev/null 2>&1; then
+        echo "✓ GraphQL endpoint is ready after $((i * CHECK_INTERVAL)) seconds"
+        exit 0
+    fi
+    echo "Waiting... ($i/$MAX_ATTEMPTS)"
+    sleep "${CHECK_INTERVAL}"
+done
+
+echo "✗ GraphQL endpoint not available after ${TIMEOUT_SECONDS} seconds"
+exit 1

--- a/.github/workflows/test-graphql-compatibility.yml
+++ b/.github/workflows/test-graphql-compatibility.yml
@@ -1,0 +1,83 @@
+name: GraphQL Compatibility Tests
+
+# This workflow tests GraphQL queries against both OCaml and Rust Mina nodes
+# to ensure compatibility between implementations.
+#
+# To run locally using act (installed via gh CLI):
+#   gh extension install https://github.com/nektos/gh-act
+#   gh act --workflows .github/workflows/test-graphql-compatibility.yml
+#
+# Or if act is installed directly:
+#   act -W .github/workflows/test-graphql-compatibility.yml
+#
+# To run a specific job:
+#   gh act --workflows .github/workflows/test-graphql-compatibility.yml --job test-ocaml-node-graphql
+#
+# Prerequisites for local runs:
+#   - Docker (for running OCaml node)
+#   - curl and jq (for GraphQL queries)
+#   - The website GraphQL scripts must be present
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Run daily at 02:00 UTC
+    - cron: "0 2 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  # OCaml node configuration
+  OCAML_NODE_IMAGE: gcr.io/o1labs-192920/mina-daemon:3.3.0-alpha1-6929a7e-noble-devnet
+  PEER_LIST_URL: https://storage.googleapis.com/o1labs-gitops-infrastructure/devnet/seed-list-devnet.txt
+
+jobs:
+  test-ocaml-node-graphql:
+    name: Test GraphQL Queries Against OCaml Node
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Start OCaml node
+        run: |
+          echo "Starting OCaml node using Docker..."
+          # Create a config directory
+          mkdir -p ocaml-node-config
+          # Use the specified Docker image
+          echo "Pulling OCaml node Docker image..."
+          docker pull $OCAML_NODE_IMAGE
+          # Run the OCaml node in Docker with GraphQL port exposed
+          docker run -d \
+            --name ocaml-mina-node \
+            -p 3085:3085 \
+            -v $(pwd)/ocaml-node-config:/root/.mina-config \
+            $OCAML_NODE_IMAGE \
+            daemon \
+            --rest-port 3085 \
+            --insecure-rest-server \
+            --file-log-level Debug \
+            --log-level Info \
+            --config-directory /root/.mina-config \
+            --peer-list-url $PEER_LIST_URL
+          # Wait for the node to start and sync (may take several minutes)
+          ./.github/scripts/test-graphql-remote/wait-for-graphql.sh "http://localhost:3085/graphql" 600 10
+          echo "OCAML_GRAPHQL_ENDPOINT=http://localhost:3085/graphql" >> $GITHUB_ENV
+      - name: Install jq for JSON processing
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq
+      - name: Test GraphQL command scripts against OCaml node
+        run: |
+          echo "Testing all GraphQL command scripts against OCaml node..."
+          GRAPHQL_ENDPOINT="$OCAML_GRAPHQL_ENDPOINT" ./.github/scripts/test-graphql-command-scripts.sh
+
+      - name: Cleanup
+        if: always()
+        run: |
+          echo "Stopping Docker container..."
+          docker stop ocaml-mina-node || true
+          docker rm ocaml-mina-node || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CI**: add workflow to test GraphQL queries with the OCaml node
+  ([#1465](https://github.com/o1-labs/mina-rust/pull/1465))
 - **Website**: add o1Labs infrastructure entry, describing the nodes managed by
   o1Labs, including seed and plain nodes
   ([#1430](https://github.com/o1-labs/mina-rust/pull/1430)). The infrastructure

--- a/website/docs/developers/scripts/update-ocaml-node.sh
+++ b/website/docs/developers/scripts/update-ocaml-node.sh
@@ -61,6 +61,7 @@ sed -i'' -e "s/config_${old_hash}/config_${new_hash}/g" "${config_files[@]}"
 # Check if version-hash pattern exists in the files
 version_files=(
     "${base_dir}/.github/workflows/tests.yaml"
+    "${base_dir}/.github/workflows/test-graphql-compatibility.yml"
     "${base_dir}/docker-compose.archive.devnet.compare.yml"
     "${base_dir}/node/testing/src/node/ocaml/config.rs"
 )


### PR DESCRIPTION
This will be useful to check that we stay compatible with the OCaml node, and in particular that all GraphQL endpoints tested with the Rust nodes are also implemented in the OCaml node.

Complementary to https://github.com/o1-labs/mina-rust/pull/1466