### PR TITLE
Website: remove mentions of frontend docker image needing work

### DIFF
--- a/ledger/src/proofs/circuit_blobs.rs
+++ b/ledger/src/proofs/circuit_blobs.rs
@@ -191,7 +191,6 @@ pub async fn fetch(filename: &impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
         option_env!("CIRCUIT_BLOBS_HTTP_PREFIX").unwrap_or("/assets/webnode/circuit-blobs");
     let url = format!("{prefix}/{}", filename.as_ref().to_str().unwrap());
     mina_core::http::get_bytes(&url).await
-    // http::get_bytes(&git_release_url(filename)).await
 }
 
 #[cfg(target_family = "wasm")]

--- a/website/docs/node-operators/block-producer.md
+++ b/website/docs/node-operators/block-producer.md
@@ -145,20 +145,6 @@ Ensure Docker and Docker Compose are installed on your system -
    Visit [http://localhost:8070](http://localhost:8070) to monitor sync and
    block production.
 
-   <!-- prettier-ignore-start -->
-
-   :::note Frontend Status
-
-   The dashboard is currently being updated and may not work correctly in
-   v0.17.0. As an alternative, monitor your node using logs:
-
-   ```bash
-   docker compose logs -f
-   ```
-
-   :::
-   <!-- prettier-ignore-stop -->
-
 ## Using Make Command
 
 As an alternative to Docker Compose, you can run the block producer directly

--- a/website/docs/node-operators/docker-usage.md
+++ b/website/docs/node-operators/docker-usage.md
@@ -91,18 +91,6 @@ You can find available tags at:
 - [o1labs/mina-rust on Docker Hub](https://hub.docker.com/r/o1labs/mina-rust/tags)
 - [o1labs/mina-rust-frontend on Docker Hub](https://hub.docker.com/r/o1labs/mina-rust-frontend/tags)
 
-<!-- prettier-ignore-start -->
-
-:::note Frontend Dashboard
-
-The frontend dashboard is currently being updated and will be fully functional
-in a future release. The Docker image is available but may not work as expected
-in v0.17.0.
-
-:::
-
-<!-- prettier-ignore-stop -->
-
 ## Architecture Support
 
 All Docker images are built natively for multiple architectures to ensure
@@ -149,7 +137,7 @@ docker run -p 8302:8302 o1labs/mina-rust:latest
 # Run node and web dashboard together
 docker run -d --name mina-rust-node -p 8302:8302 o1labs/mina-rust:latest \
   node --network devnet
-# Frontend (currently being fixed, may not work as expected)
+# Frontend
 docker run -d --name mina-frontend -p 8070:8070 o1labs/mina-rust-frontend:latest
 ```
 
@@ -157,18 +145,6 @@ docker run -d --name mina-frontend -p 8070:8070 o1labs/mina-rust-frontend:latest
 
 Docker Compose provides the easiest way to run both the Mina node and frontend
 dashboard together.
-
-<!-- prettier-ignore-start -->
-
-:::caution Frontend Status
-
-The frontend dashboard is included in the docker-compose setup but is currently
-being updated. It may not function correctly in v0.17.0 and will be fully
-operational in a future release.
-
-:::
-
-<!-- prettier-ignore-stop -->
 
 #### Quick Start with Release Version
 
@@ -242,8 +218,7 @@ MINA_LIBP2P_PORT=9302 MINA_LIBP2P_EXTERNAL_IP=203.0.113.1 docker compose up -d
 #### What's Included
 
 - **mina-rust-node**: The core Mina Rust node running on devnet
-- **frontend**: Web dashboard accessible at http://localhost:8070 (currently
-  being fixed)
+- **frontend**: Web dashboard accessible at http://localhost:8070
 - **Persistent storage**: Node data stored in `./mina-workdir` directory
 - **Automatic networking**: Services can communicate with each other
 


### PR DESCRIPTION
The frontend docker image has been revamped and is now fully functional. Removed all mentions from the documentation indicating it was being updated or might not work as expected.

Fixes: https://github.com/o1-labs/mina-rust/issues/1399

Changes:
- Removed frontend status warnings from docker-usage.md
- Removed frontend status note from block-producer.md
- Cleaned up trailing whitespace in circuit_blobs.rs